### PR TITLE
Add error handling for transients

### DIFF
--- a/etap-mailchimp.php
+++ b/etap-mailchimp.php
@@ -33,9 +33,15 @@ if (is_soap_fault($nsc)) {
 
 // Invoke login method
 
-#echo "Calling login method...";
-$newEndpoint = $nsc->__soapCall("apiKeyLogin", array($databaseId, $apiKey));
-#echo "Done\n";
+try {
+  #echo "Calling login method...";
+  $newEndpoint = $nsc->__soapCall("apiKeyLogin", array($databaseId, $apiKey));
+  #echo "Done\n";
+} catch (Exception $e) {
+  echo "Caught exception: ", $e->getMessage(), "\n";
+  echo "Could not log in to E-tapestry.  Giving up.\n";
+  exit;
+}
 
 // Did we login?
 if (is_soap_fault($newEndpoint)) {


### PR DESCRIPTION
We got this error:

PHP Fatal error:  Uncaught SoapFault exception: [HTTP] Error Fetching http headers in rvrn/etap-mailchimp.php:37 Stack trace:
  thrown in rvrn/etap-mailchimp.php on line 37
Null message body; hope that's ok

And this is even right after checking for soap errors. So add another try/catch wrapper for this error condition.