### PR TITLE
stop using deprecated api key and use personal access token instead

### DIFF
--- a/airtable-libs.php
+++ b/airtable-libs.php
@@ -13,7 +13,7 @@ function email_exists_in_airtable($email_to_find = "") {
   $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
   $dotenv->load();
 
-  $airtable_api = $_ENV['AIRTABLE_API_KEY'];
+  $airtable_api = $_ENV['AIRTABLE_ACCESS_TOKEN'];
   $base_id      = $_ENV['AIRTABLE_BASE_ID'];
   $table_id     = $_ENV['AIRTABLE_TABLE_ID'];
 
@@ -63,7 +63,7 @@ function add_to_airtable($person) {
 
   $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
   $dotenv->load();
-  $airtable_api = $_ENV['AIRTABLE_API_KEY'];
+  $airtable_api = $_ENV['AIRTABLE_ACCESS_TOKEN'];
   $base_id      = $_ENV['AIRTABLE_BASE_ID'];
   $table_id     = $_ENV['AIRTABLE_TABLE_ID'];
   date_default_timezone_set('America/Los_Angeles');
@@ -127,7 +127,7 @@ function add_to_airtable($person) {
 function get_airtable_list($list,$view) {
   $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
   $dotenv->load();
-  $airtable_api = $_ENV['AIRTABLE_API_KEY'];
+  $airtable_api = $_ENV['AIRTABLE_ACCESS_TOKEN'];
   $base_id      = $_ENV['AIRTABLE_BASE_ID'];
 
   $mylist = rawurlencode($list);


### PR DESCRIPTION
Airtable has deprecated the use of API keys in favor of personal access tokens.  This change moves to the use of personal access tokens.

Background from an Airtable communication:
In January, we launched new API authentication methods, personal access tokens and OAuth integrations, which are replacing Airtable API keys.

How does this impact you? API keys (and therefore, any integration that used them to connect with Airtable) will continue to work until February 1st 2024. However, to ensure continued access to the Airtable API, you will need to start using the new authentication methods before February 1st 2024.

If you or a developer on your team has used an Airtable API key to build API integrations with Airtable, please migrate to using personal access tokens to authenticate your API requests before February 1st 2024. Your API key usage can be directly replaced with a personal access token provided as an Authorization: Bearer header. 
