### PR TITLE
tone down verbosity

### DIFF
--- a/etap-mailchimp-journal-updates.php
+++ b/etap-mailchimp-journal-updates.php
@@ -49,11 +49,11 @@ if (is_soap_fault($newEndpoint)) {
 // environment that can only be accessed using the provided endpoint
 if ($newEndpoint != "")
 {
-  echo "New Endpoint: $newEndpoint<br><br>\n";
+  #echo "New Endpoint: $newEndpoint<br><br>\n";
   // Instantiate SoapClient with different endpoint
-  echo "Establishing Soap Client with new endpoint...";
+  #echo "Establishing Soap Client with new endpoint...";
   $nsc = new SoapClient($newEndpoint);
-  echo "Done\n";
+  #echo "Done\n";
 
   // Invoke login method
   #echo "Calling login method...";

--- a/etap-mailchimp.php
+++ b/etap-mailchimp.php
@@ -54,11 +54,11 @@ if (is_soap_fault($newEndpoint)) {
 // environment that can only be accessed using the provided endpoint
 if ($newEndpoint != "")
 {
-  echo "New Endpoint: $newEndpoint<br><br>\n";
+  #echo "New Endpoint: $newEndpoint<br><br>\n";
   // Instantiate SoapClient with different endpoint
-  echo "Establishing Soap Client with new endpoint...";
+  #echo "Establishing Soap Client with new endpoint...";
   $nsc = new SoapClient($newEndpoint);
-  echo "Done\n";
+  #echo "Done\n";
 
   // Invoke login method
   #echo "Calling login method...";

--- a/test-etap.php
+++ b/test-etap.php
@@ -48,11 +48,11 @@ if (is_soap_fault($newEndpoint)) {
 // environment that can only be accessed using the provided endpoint
 if ($newEndpoint != "")
 {
-  echo "New Endpoint: $newEndpoint<br><br>\n";
+  #echo "New Endpoint: $newEndpoint<br><br>\n";
   // Instantiate SoapClient with different endpoint
-  echo "Establishing Soap Client with new endpoint...";
+  #echo "Establishing Soap Client with new endpoint...";
   $nsc = new SoapClient($newEndpoint);
-  echo "Done\n";
+  #echo "Done\n";
 
   // Invoke login method
   #echo "Calling login method...";


### PR DESCRIPTION
When the integration failed to connect recently and gave a null report of progress, I modified the initial endpoint where the request is made from BOS to SNA.  This hopefully will allow the integration to properly load balance our request instead of failing to log in when the service is unavailable.
Now the normal load balancing from SNA to BOS is happening.  The integration doesn't need to report when it is redirected under normal circumstances.  It is only interesting during failure.